### PR TITLE
Add a virtual module that imports all translations for a file

### DIFF
--- a/__tests__/fixtures/ftl/da/importer.js.ftl
+++ b/__tests__/fixtures/ftl/da/importer.js.ftl
@@ -1,0 +1,1 @@
+key = Translations for js file da

--- a/__tests__/fixtures/ftl/en/importer.js.ftl
+++ b/__tests__/fixtures/ftl/en/importer.js.ftl
@@ -1,0 +1,1 @@
+key = Translations for js file

--- a/__tests__/fixtures/importer.js
+++ b/__tests__/fixtures/importer.js
@@ -1,0 +1,4 @@
+import translations from 'virtual:ftl-for-file'
+
+// eslint-disable-next-line no-console -- this is a test file
+console.log(translations)

--- a/__tests__/frameworks/vite/external.spec.ts
+++ b/__tests__/frameworks/vite/external.spec.ts
@@ -71,4 +71,35 @@ describe('Vite external', () => {
     expect(code).toContain('external.setup.vue.ftl')
     expect(code).toMatchSnapshot()
   })
+
+  it('virtual:ftl-for-file', async () => {
+    // Arrange
+    // Act
+    const code = await compile({
+      plugins: [
+        vue3(),
+        ExternalFluentPlugin({
+          baseDir: resolve(baseDir, 'fixtures'),
+          ftlDir: resolve(baseDir, 'fixtures/ftl'),
+          locales: ['en', 'da'],
+        }),
+      ],
+    }, '/fixtures/importer.js')
+
+    // Assert
+    expect(code).toMatchInlineSnapshot(`
+      "=== /fixtures/importer.js ===
+      import translations from '/@id/virtual:ftl-for-file?importer=/fixtures/importer.js'
+
+      // eslint-disable-next-line no-console -- this is a test file
+      console.log(translations)
+
+
+      === virtual:ftl-for-file?importer=/fixtures/importer.js ===
+      import en_ftl from '/fixtures/ftl/en/importer.js.ftl?import';
+      import da_ftl from '/fixtures/ftl/da/importer.js.ftl?import';
+      export default { 'en': en_ftl, 'da': da_ftl }
+      "
+    `)
+  })
 })

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 interface ExternalPluginOptionsBase {
   locales: string[]
   checkSyntax?: boolean
+  virtualModuleName?: string
 }
 
 interface ExternalPluginOptionsFolder extends ExternalPluginOptionsBase {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the Contributing Guide.
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Allow to use `virtual:ftl-for-file` to import all translations for a given file

```index.ts
import translations from 'virtual:ftl-for-file`
```

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
